### PR TITLE
[jsk_rviz_plugins/camera_info_display] Check fx and fy are not equal to zero.

### DIFF
--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -432,7 +432,8 @@ namespace jsk_rviz_plugins
       ROS_ERROR("failed to create camera model");
       return;
     }
-    if (cv::countNonZero(model.intrinsicMatrix()) < 1) {
+    // fx and fy should not be equal 0.
+    if (model.fx() == 0.0 || model.fy() == 0.0) {
       setStatus(rviz::StatusProperty::Error, "Camera Info", "Invalid intrinsic matrix");
       ROS_ERROR_STREAM("camera model have invalid intrinsic matrix " << model.intrinsicMatrix());
       return;


### PR DESCRIPTION
current condition of ```cv::countNonZero(model.intrinsicMatrix()) < 1``` is not adequate to avoid crash.
We should check fx and fy are not equal to zero to use ```projectPixelTo3dRay```. 
https://github.com/ros-perception/vision_opencv/blob/kinetic/image_geometry/src/pinhole_camera_model.cpp#L282-L291